### PR TITLE
Set Vite to strict port

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,8 @@ const react          = require('@vitejs/plugin-react');
 module.exports = defineConfig({
   plugins: [react()],
   server: {
-    port: 5173      // ← lock Vite to 5173
+    port: 5173,     // ← lock Vite to 5173
+    strictPort: true
   },
   build: {
     outDir: 'dist'


### PR DESCRIPTION
## Summary
- ensure Vite uses port 5173 without falling back

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875c62a08688325be1c19ba45786117