### PR TITLE
Update build process for standalone app

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This runs both the Vite development server and the Electron process.
 
 ## Building for Production
 
-To package the application for distribution run:
+To package the application for distribution run the build script which first
+compiles the renderer with Vite and then packages the app with Electron Builder:
 
 ```bash
 npm run build

--- a/electron-main.js
+++ b/electron-main.js
@@ -14,7 +14,11 @@ function createWindow() {
       nodeIntegration: false
     }
   });
-  win.loadURL('http://localhost:5173');
+  if (app.isPackaged) {
+    win.loadFile(join(__dirname, 'dist', 'index.html'));
+  } else {
+    win.loadURL('http://localhost:5173');
+  }
 }
 
 app.whenReady().then(() => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "electron": "wait-on http://localhost:5173 && electron .",
   "dev": "concurrently \"npm run serve\" \"npm run electron\"",
   "start": "electron .",
-  "build": "electron-builder"
+  "build": "vite build && electron-builder"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^3.0.0",


### PR DESCRIPTION
## Summary
- load local `index.html` when packaged
- run `vite build` before `electron-builder`
- document updated build instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875c89fe6688325ae985e578705675f